### PR TITLE
fix: Update add-quarterly-gh-requests.yml

### DIFF
--- a/.github/workflows/add-quarterly-gh-requests.yml
+++ b/.github/workflows/add-quarterly-gh-requests.yml
@@ -1,7 +1,7 @@
 name: Create quarterly issues
 on:
   schedule:
-    - cron: 0 0 * 1,4,7,10 *
+    - cron: 0 0 1 1,4,7,10 *
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
It was previously matching any day in the given months instead of on the first day of each matching month.  This is what was causing so many tickets to get created.