### PR TITLE
feat: Create weekly tickets for on-call.

### DIFF
--- a/.github/workflows/add-weekly-gh-requests.yml
+++ b/.github/workflows/add-weekly-gh-requests.yml
@@ -1,0 +1,20 @@
+name: Create weekly issues
+on:
+  schedule:
+    - cron: 0 0 * * 0 
+  workflow_dispatch: {}
+
+jobs:
+  create_issue:
+    name: Create weeksly issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: |
+          gh issue create --repo "openedx/axim-engineering" \
+            --title "Welcome new discourse members" \
+            --label "github-request" \
+            --body "Go through [new discourse introductions](https://discuss.openedx.org/c/community/introductions/18) and welcome new people to the community."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I tried to do things bi-weekly but that's actually not easily possible
with the versino of cron that Github uses.  So we'll settle for doing
this every week which is not a bad situation.
