### PR TITLE
fix: fallback check for identifying github requests

### DIFF
--- a/.github/workflows/add-GHrequest-to-team-board.yml
+++ b/.github/workflows/add-GHrequest-to-team-board.yml
@@ -28,7 +28,7 @@ jobs:
   add_label:
     runs-on: ubuntu-latest
     # This is defined on all 2 jobs - so need to change x2 if changing this.
-    if: ${{ (contains(github.event.issue.title, '[GH Request]') || startsWith(github.event.issue.body, 'Firm Name')) && !contains(github.event.issue.labels.*.name, 'github-request') }}
+    if: ${{ (contains(github.event.issue.title, '[GH Request]') || startsWith(github.event.issue.body, '## Firm Name')) && !contains(github.event.issue.labels.*.name, 'github-request') }}
     steps:
       - name: apply github-request label
         uses: actions-ecosystem/action-add-labels@v1
@@ -37,7 +37,7 @@ jobs:
 
   move_and_notify:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.issue.title, '[GH Request]') || startsWith(github.event.issue.body, 'Firm Name') || contains(github.event.issue.labels.*.name, 'github-request')}}
+    if: ${{ contains(github.event.issue.title, '[GH Request]') || startsWith(github.event.issue.body, '## Firm Name') || contains(github.event.issue.labels.*.name, 'github-request')}}
     steps:
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
Sometimes requesters will remove `[GH Request]` from their issue title without
realizing the implications, so we have a fall back check for `Firm Name` as the
beginning of the request body.

This fallback check is a great idea but it was broken  because the request
template actually generates issues beginning with `## Firm Name`, not
`Firm Name`. This commit should fix that, making it less likely that we miss oncall
requests in the future.
