### PR TITLE
fix: Pass the github token to all jobs in the workflows.

### DIFF
--- a/.github/workflows/add-quarterly-gh-requests.yml
+++ b/.github/workflows/add-quarterly-gh-requests.yml
@@ -4,6 +4,9 @@ on:
     - cron: 0 0 1 1,4,7,10 *
   workflow_dispatch: {}
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   create_issue:
     name: Create quarterly issues
@@ -23,5 +26,3 @@ jobs:
             --title "Quarterly repo-checks.py Run" \
             --label "github-request" \
             --body "It is time to perform the quartely run of \`repo-checks.py\` for the \`openedx\` org.  Instructions for running the script can be found [here](https://github.com/openedx/repo-tools/tree/master/edx_repo_tools/repo_checks#usage)."
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-weekly-gh-requests.yml
+++ b/.github/workflows/add-weekly-gh-requests.yml
@@ -1,8 +1,11 @@
 name: Create weekly issues
 on:
   schedule:
-    - cron: 0 0 * * 0 
+    - cron: 0 0 * * 0
   workflow_dispatch: {}
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   create_issue:
@@ -16,5 +19,3 @@ jobs:
             --title "Welcome new discourse members" \
             --label "github-request" \
             --body "Go through [new discourse introductions](https://discuss.openedx.org/c/community/introductions/18) and welcome new people to the community."
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We weren't passing the GITHUB_TOKEN to both steps of the quarterly task
which was causing it to fail on the first step which didn't pass the
GITHUB_TOKEN.

Rather than just fixing the one step, I updated both the quarterly and
weekly file to pass the GITHUB_TOKEN env to all jobs/steps in their
respective workflow files.  Since these files should be only github
issue creation commands I think this is fine to do and simplifes things
and makes the workflows less error prone.
