### PR TITLE
build: Fix quarterly job alert by echoing var to env

### DIFF
--- a/.github/workflows/add-quarterly-GH-audit.yml
+++ b/.github/workflows/add-quarterly-GH-audit.yml
@@ -16,10 +16,11 @@ jobs:
     steps:
       - run: |
           # Audit GitHub Users
-          gh issue create --repo "openedx/axim-engineering" \
+          new_issue_url=$(gh issue create --repo "openedx/axim-engineering" \
             --title "Quarterly Audit of Github Users" \
             --label "github-request" \
-            --body "It is time to perform the quartely audit of GitHub users in the \`openedx\` org.  The playbook for performing the audit can be found [here](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3438903337/On-call+Playbooks#%F0%9F%94%8D-Audit-Github-Users)."
+            --body "It is time to perform the quartely audit of GitHub users in the \`openedx\` org.  The playbook for performing the audit can be found [here](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3438903337/On-call+Playbooks#%F0%9F%94%8D-Audit-Github-Users).")
+            echo "NEW_ISSUE_URL=$new_issue_url" >> $GITHUB_ENV
 
       - name: Comment on issue
         run: gh issue comment $NEW_ISSUE_URL --body "@openedx/axim-oncall heads up on this request"

--- a/.github/workflows/add-quarterly-repo-checks.yml
+++ b/.github/workflows/add-quarterly-repo-checks.yml
@@ -16,10 +16,11 @@ jobs:
     steps:
       - run: |
           # Run repo-checks.py
-          gh issue create --repo "openedx/axim-engineering" \
+          new_issue_url=$(gh issue create --repo "openedx/axim-engineering" \
             --title "Quarterly repo-checks.py Run" \
             --label "github-request" \
-            --body "It is time to perform the quartely run of \`repo-checks.py\` for the \`openedx\` org.  Instructions for running the script can be found [here](https://github.com/openedx/repo-tools/tree/master/edx_repo_tools/repo_checks#usage)."
+            --body "It is time to perform the quartely run of \`repo-checks.py\` for the \`openedx\` org.  Instructions for running the script can be found [here](https://github.com/openedx/repo-tools/tree/master/edx_repo_tools/repo_checks#usage).")
+            echo "NEW_ISSUE_URL=$new_issue_url" >> $GITHUB_ENV
 
       - name: Comment on issue
         run: gh issue comment $NEW_ISSUE_URL --body "@openedx/axim-oncall heads up on this request"


### PR DESCRIPTION
See prior art at https://github.com/openedx/axim-engineering/blob/main/.github/workflows/add-weekly-gh-requests.yml - we need to echo the var to the environment so the next job step can pick it up.

@arbrandes could you review as part of on-call? Note that https://github.com/openedx/axim-engineering/issues/1267 was made by the first step in this job, but didn't tag you or notify our chat.
